### PR TITLE
Fix the example documentation;

### DIFF
--- a/lib/simplecov_json/plugin.rb
+++ b/lib/simplecov_json/plugin.rb
@@ -8,7 +8,7 @@ module Danger
   #
   # @example Report code coverage
   #
-  #          simplecov.report_coverage('coverage/coverage.json')
+  #          simplecov.report('coverage/coverage.json')
   #
   # @see  marcelofabri/danger-simplecov_json
   # @tags ruby, code-coverage, simplecov


### PR DESCRIPTION
Has just integrated the simplecov plugin and found the auto-generated documentation is outdated on the danger.systems :disappointed:

Example has to be changed from:
```
simplecov.report_coverage('coverage/coverage.json')
```

to
```
simplecov.report('coverage/coverage.json')
```