### PR TITLE
Remove useless path in individual code coverage report

### DIFF
--- a/lib/simplecov_json/plugin.rb
+++ b/lib/simplecov_json/plugin.rb
@@ -51,6 +51,10 @@ module Danger
         covered_files = JSON.parse(File.read(coverage_path), symbolize_names: true)[:files]
                             .select { |f| committed_files.include?(f[:filename]) }
 
+        unless current_project_path.nil?
+          covered_files.each { |f| f[:filename].sub!(%r{^#{current_project_path}/?}, '') }
+        end
+
         return if covered_files.nil? || covered_files.empty?
         markdown individual_coverage_message(covered_files)
       else

--- a/spec/fixtures/fullpath_coverage.json
+++ b/spec/fixtures/fullpath_coverage.json
@@ -1,0 +1,13 @@
+{
+   "timestamp":1471917899,
+   "command_name":"RSpec",
+   "files":[
+     { "filename": "/foo/bar/current/another_ruby_file.rb", "covered_percent": 20.0 }
+   ],
+   "metrics":{
+      "covered_percent":99.14754098360656,
+      "covered_strength":31.564786885245905,
+      "covered_lines":1512,
+      "total_lines":1525
+   }
+}

--- a/spec/simplecov_json_spec.rb
+++ b/spec/simplecov_json_spec.rb
@@ -29,6 +29,17 @@ module Danger
           '| another_ruby_file.rb | 20.00%   |')
       end
 
+      it 'Shows individual code coverage report with current project path' do
+        allow(@simplecov.git).to receive(:added_files).and_return([])
+        allow(@simplecov.git).to receive(:modified_files)
+          .and_return(['another_ruby_file.rb'])
+
+        @simplecov.individual_report('spec/fixtures/fullpath_coverage.json', '/foo/bar/current')
+        expect(@dangerfile.status_report[:markdowns][0].message).to eq("### Code Coverage\n\n"\
+          "| File                 | Coverage |\n|----------------------|----------|\n"\
+          '| another_ruby_file.rb | 20.00%   |')
+      end
+
       it 'Fails if code coverage not found' do
         @simplecov.report('spec/fixtures/missing_file.json')
 


### PR DESCRIPTION
`simplecov.individual_report('coverage/coverage.json', Dir.pwd)`
outputs coverage for files with fullpath, like:

```
| File                                  | Coverage |
|---------------------------------------|----------|
| /foo/bar/current/another_ruby_file.rb | 20.00%   |
```

Remove useless path, tables now become as follows:

```
| File                 | Coverage |
|----------------------|----------|
| another_ruby_file.rb | 20.00%   |